### PR TITLE
Handler items can ignore transfomations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,5 +20,9 @@ and size is equal to new size.
 You can change pen and brush for resizer handles using `setPen` and `setBrush`
 methods.
 
+Use `setHandlersIgnoreTransformations` to force handler items ignore all transformations. 
+For example, it would be useful when attached graphics views can be zoomed or rotated -
+handlers will have the same size and relative position.
+
 ### License
 Resizer item is licensed under the Apache License, Version 2.0. See LICENSE for details.

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -4,7 +4,6 @@
 #include "resizer/graphicsitemresizer.h"
 
 #include <QGraphicsRectItem>
-#include <QDebug>
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -4,6 +4,7 @@
 #include "resizer/graphicsitemresizer.h"
 
 #include <QGraphicsRectItem>
+#include <QDebug>
 
 MainWindow::MainWindow(QWidget *parent) :
     QMainWindow(parent),
@@ -23,6 +24,7 @@ MainWindow::MainWindow(QWidget *parent) :
     resizer->setBrush(QColor(64, 64, 64));
     resizer->setMinSize(QSizeF(30, 30));
     resizer->setTargetSize(item->boundingRect().size());
+    resizer->setHandlersIgnoreTransformations(true);
     QObject::connect(resizer, &GraphicsItemResizer::targetRectChanged, [item](const QRectF &rect)
     {
         QPointF pos = item->pos();
@@ -33,6 +35,15 @@ MainWindow::MainWindow(QWidget *parent) :
 
     ui->graphicsView->setScene(scene);
     ui->graphicsView->setAlignment(Qt::AlignTop | Qt::AlignLeft);
+
+    ui->graphicsView->setTransformationAnchor(QGraphicsView::AnchorUnderMouse);
+
+    connect(ui->plusButton, &QPushButton::clicked, this, [&]() {
+        ui->graphicsView->scale(1.2, 1.2);
+    });
+    connect(ui->minusButton, &QPushButton::clicked, this, [&]() {
+        ui->graphicsView->scale((1.0 / 1.2), (1.0 / 1.2));
+    });
 }
 
 MainWindow::~MainWindow()

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -14,21 +14,36 @@
    <string>Item resizer demo</string>
   </property>
   <widget class="QWidget" name="centralWidget">
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <property name="leftMargin">
-     <number>4</number>
-    </property>
-    <property name="topMargin">
-     <number>4</number>
-    </property>
-    <property name="rightMargin">
-     <number>4</number>
-    </property>
-    <property name="bottomMargin">
-     <number>4</number>
+   <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0">
+    <property name="sizeConstraint">
+     <enum>QLayout::SetMinimumSize</enum>
     </property>
     <item>
      <widget class="QGraphicsView" name="graphicsView"/>
+    </item>
+    <item>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetMinimumSize</enum>
+      </property>
+      <item>
+       <widget class="QPushButton" name="plusButton">
+        <property name="text">
+         <string>+</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="minusButton">
+        <property name="text">
+         <string>-</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="widget" native="true"/>
+      </item>
+     </layout>
     </item>
    </layout>
   </widget>

--- a/resizer/graphicsitemresizer.cpp
+++ b/resizer/graphicsitemresizer.cpp
@@ -13,20 +13,18 @@ GraphicsItemResizer::GraphicsItemResizer(QGraphicsItem *parent)
     , mTargetSize(0, 0)
     , mMinSize(0, 0)
 {
-    static QRectF handleRect(QPointF(), handleSize);
-
     setFlag(ItemHasNoContents);
 
     // sides
-    mHandleItems.append(new HandleItem(HandleItem::Left, handleRect, this));
-    mHandleItems.append(new HandleItem(HandleItem::Top, handleRect, this));
-    mHandleItems.append(new HandleItem(HandleItem::Right, handleRect, this));
-    mHandleItems.append(new HandleItem(HandleItem::Bottom, handleRect, this));
+    mHandleItems.append(new HandleItem(HandleItem::Left, handleSize, this));
+    mHandleItems.append(new HandleItem(HandleItem::Top, handleSize, this));
+    mHandleItems.append(new HandleItem(HandleItem::Right, handleSize, this));
+    mHandleItems.append(new HandleItem(HandleItem::Bottom, handleSize, this));
     // corners
-    mHandleItems.append(new HandleItem(HandleItem::Top | HandleItem::Left, handleRect, this));
-    mHandleItems.append(new HandleItem(HandleItem::Top | HandleItem::Right, handleRect, this));
-    mHandleItems.append(new HandleItem(HandleItem::Bottom | HandleItem::Right, handleRect, this));
-    mHandleItems.append(new HandleItem(HandleItem::Bottom | HandleItem::Left, handleRect, this));
+    mHandleItems.append(new HandleItem(HandleItem::Top | HandleItem::Left, handleSize, this));
+    mHandleItems.append(new HandleItem(HandleItem::Top | HandleItem::Right, handleSize, this));
+    mHandleItems.append(new HandleItem(HandleItem::Bottom | HandleItem::Right, handleSize, this));
+    mHandleItems.append(new HandleItem(HandleItem::Bottom | HandleItem::Left, handleSize, this));
 }
 
 GraphicsItemResizer::~GraphicsItemResizer()
@@ -77,6 +75,22 @@ void GraphicsItemResizer::setTargetSize(const QSizeF &size)
 void GraphicsItemResizer::setMinSize(const QSizeF &minSize)
 {
     mMinSize = minSize;
+}
+
+bool GraphicsItemResizer::handlersIgnoreTransformations() const
+{
+    return mHandlersIgnoreTransformations;
+}
+
+void GraphicsItemResizer::setHandlersIgnoreTransformations(bool ignore)
+{
+    if (mHandlersIgnoreTransformations != ignore)
+    {
+        mHandlersIgnoreTransformations = ignore;
+
+        for (auto handleItem : mHandleItems)
+            handleItem->setFlag(ItemIgnoresTransformations, ignore);
+    }
 }
 
 void GraphicsItemResizer::updateHandleItemPositions()

--- a/resizer/graphicsitemresizer.h
+++ b/resizer/graphicsitemresizer.h
@@ -4,6 +4,7 @@
 #include <QObject>
 #include <QGraphicsItem>
 #include <QPen>
+#include <QGraphicsView>
 
 class GraphicsItemResizer : public QObject, public QGraphicsItem
 {
@@ -23,6 +24,10 @@ public:
     void setMinSize(const QSizeF &minSize);
 
     inline QSizeF targetSize() const;
+
+    bool handlersIgnoreTransformations() const;
+    // If true, handler items ignore all transformations e.g. zooming the view etc
+    void setHandlersIgnoreTransformations(bool ignore);
 
 public slots:
     void setTargetSize(const QSizeF &size);
@@ -48,6 +53,8 @@ private:
     QSizeF mTargetSize;
     QSizeF mMinSize;
     QRectF mBounds;
+
+    bool mHandlersIgnoreTransformations = false;
 };
 
 QBrush GraphicsItemResizer::brush() const

--- a/resizer/handlerstrategies.cpp
+++ b/resizer/handlerstrategies.cpp
@@ -39,7 +39,7 @@ void TopHandlerStrategy::solveConstraints(QPointF offset, QSizeF minSize, QRectF
 
 void TopHandlerStrategy::alignPosition(const QRectF &targetRect, QPointF &position)
 {
-    position.setY(0);
+    position.setY(targetRect.top());
     HandlerStrategy::alignPosition(targetRect, position);
 }
 
@@ -83,7 +83,7 @@ void LeftHandlerStrategy::solveConstraints(QPointF offset, QSizeF minSize, QRect
 
 void LeftHandlerStrategy::alignPosition(const QRectF &targetRect, QPointF &position)
 {
-    position.setX(0);
+    position.setX(targetRect.left());
     HandlerStrategy::alignPosition(targetRect, position);
 }
 

--- a/resizer/resizehandleitem.cpp
+++ b/resizer/resizehandleitem.cpp
@@ -4,7 +4,6 @@
 #include <QBrush>
 #include <QCursor>
 #include <QGraphicsSceneMouseEvent>
-#include <QDebug>
 
 QHash<int, QWeakPointer<HandlerStrategy>> GraphicsItemResizer::HandleItem::Strategies;
 
@@ -25,7 +24,7 @@ GraphicsItemResizer::HandleItem::HandleItem(int attachmentFlags, const QRectF &r
 }
 
 GraphicsItemResizer::HandleItem::HandleItem(int attachmentFlags, const QSizeF &size, GraphicsItemResizer *resizer)
-    : HandleItem(attachmentFlags, handlerRect(attachmentFlags, size), resizer)
+    : HandleItem(attachmentFlags, handleRect(attachmentFlags, size), resizer)
 
 {
 
@@ -43,7 +42,7 @@ GraphicsItemResizer *GraphicsItemResizer::HandleItem::resizer() const
     return mResizer;
 }
 
-QRectF GraphicsItemResizer::HandleItem::handlerRect(int attachment, const QSizeF& size) const
+QRectF GraphicsItemResizer::HandleItem::handleRect(int attachment, const QSizeF& size) const
 {
     double w = size.width();
     double h = size.height();
@@ -163,7 +162,6 @@ void GraphicsItemResizer::HandleItem::mouseMoveEvent(QGraphicsSceneMouseEvent *e
         event->ignore();
         return;
     }
-    QPointF mousePos = event->pos();
     QPointF offset = event->scenePos() - event->lastScenePos();
     QRectF targetRect(QPointF(), resizer()->targetSize());
     QSizeF minSize = resizer()->minSize();

--- a/resizer/resizehandleitem.h
+++ b/resizer/resizehandleitem.h
@@ -19,7 +19,11 @@ public:
         Right = 0x8
     };
 
+    constexpr static int HorizontalMask = HandleItem::Left | HandleItem::Right;
+    constexpr static int VerticalMask = HandleItem::Top | HandleItem::Bottom;
+
     explicit HandleItem(int attachmentFlags, const QRectF &rect, GraphicsItemResizer *resizer);
+    explicit HandleItem(int attachmentFlags, const QSizeF &size, GraphicsItemResizer *resizer);
 
     int attachmentFlags() const
     {
@@ -36,6 +40,8 @@ protected:
 
 private:
     GraphicsItemResizer *resizer() const;
+
+    QRectF handlerRect(int attachment, const QSizeF &size) const;
 
     GraphicsItemResizer *mResizer;
     int mAttachmentFlags;

--- a/resizer/resizehandleitem.h
+++ b/resizer/resizehandleitem.h
@@ -41,7 +41,7 @@ protected:
 private:
     GraphicsItemResizer *resizer() const;
 
-    QRectF handlerRect(int attachment, const QSizeF &size) const;
+    QRectF handleRect(int attachment, const QSizeF &size) const;
 
     GraphicsItemResizer *mResizer;
     int mAttachmentFlags;


### PR DESCRIPTION
Resizer handle items can ignore view and scene transformation by using `GraphicsItemResizer::setHandlersIgnoreTransformations(bool)`. For example, it would be useful when attached graphics views can be zoomed or rotated - handlers will have the same size and relative position. A lot of graphics editors resize handlers are implemented like that.
![1](https://user-images.githubusercontent.com/32900211/122604804-98580600-d087-11eb-8cf2-5d750f724fde.png)
![2](https://user-images.githubusercontent.com/32900211/122604808-9a21c980-d087-11eb-8b00-b1cbf0ce38dc.png)
![3](https://user-images.githubusercontent.com/32900211/122604820-9db55080-d087-11eb-9072-e8defde06406.png)